### PR TITLE
Upgrade template manifest to VS 2019

### DIFF
--- a/NewRhinoCommonTemplate/source.extension.vsixmanifest
+++ b/NewRhinoCommonTemplate/source.extension.vsixmanifest
@@ -18,7 +18,7 @@ Copyright (c) 2016-2019 Robert McNeel and Associates. All rights reserved.</Desc
         <Tags>rhinocommon grasshopper</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -33,6 +33,6 @@ Copyright (c) 2016-2019 Robert McNeel and Associates. All rights reserved.</Desc
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Addresses issue #9. 
- Successfully installed extension in VS 2019.
- Successfully built and installed the default Rhino command project

I used this [guide](https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/) for the procedure.